### PR TITLE
Add version flags and improve helper

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,10 +10,27 @@ import (
 )
 
 func main() {
+	versionFlag := flag.Bool("version", false, "Print version information")
+	flag.BoolVar(versionFlag, "v", false, "Print version information")
 	flag.Parse()
 
+	if *versionFlag {
+		fmt.Printf("v%s\n", services.SQD_VERSION)
+		os.Exit(0)
+	}
+
 	if len(flag.Args()) == 0 {
-		fmt.Println("Usage: sqd 'SELECT * FROM file.txt WHERE content LIKE pattern'")
+		fmt.Println("Usage: sqd 'query'")
+		fmt.Println("\nCommands:")
+		fmt.Println("  SELECT - Display matching lines")
+		fmt.Println("  UPDATE - Replace content in matching lines")
+		fmt.Println("  DELETE - Remove matching lines")
+		fmt.Println("\nExamples:")
+		fmt.Println("  sqd 'SELECT * FROM file.txt WHERE content LIKE pattern'")
+		fmt.Println("  sqd 'UPDATE file.txt SET old TO new WHERE content = match, SET foo TO bar WHERE content = other'")
+		fmt.Println("  sqd 'DELETE FROM file.txt WHERE content = exact_match'")
+		fmt.Println("\nFlags:")
+		fmt.Println("  -v, --version    Show the version information")
 		os.Exit(1)
 	}
 

--- a/services/utils.go
+++ b/services/utils.go
@@ -8,6 +8,8 @@ import (
 	"syscall"
 )
 
+const SQD_VERSION = "0.0.2"
+
 func PrintUpdateMessage(total int) {
 	fmt.Printf("Updated: %d occurrences\n", total)
 }


### PR DESCRIPTION
This PR is make to add version flags and improve the helper command to make sqd easier to use and manage across versions, especially in a developer setup where it’s installed via `go install` for development purposes.