### PR TITLE
Remove unnecessary abstractions

### DIFF
--- a/services/dry_runner.go
+++ b/services/dry_runner.go
@@ -10,13 +10,12 @@ import (
 )
 
 type DryRunner struct {
-	fileOperations FileOperations
-	utils          *Utils
-	fileOperator   *FileOperator
+	utils        *Utils
+	fileOperator *FileOperator
 }
 
-func NewDryRunner(fileOperations FileOperations, utils *Utils) *DryRunner {
-	return &DryRunner{fileOperations: fileOperations, utils: utils}
+func NewDryRunner(utils *Utils) *DryRunner {
+	return &DryRunner{utils: utils}
 }
 
 func (dryRunner *DryRunner) Validate(command models.Command, files []string, stats *models.ExecutionStats, useTransaction bool) bool {
@@ -37,12 +36,12 @@ func (dryRunner *DryRunner) Validate(command models.Command, files []string, sta
 	}
 
 	if command.Action == models.UPDATE {
-		dryRunner.utils.PrintUpdateMessage(total)
+		dryRunner.utils.printUpdateMessage(total)
 	} else {
 		fmt.Printf("Deleted: %d lines\n", total)
 	}
 
-	dryRunner.utils.PrintStats(*stats)
+	dryRunner.utils.printStats(*stats)
 	return true
 }
 
@@ -139,12 +138,12 @@ func (dryRunner *DryRunner) validateAndReadFile(file string, stats *models.Execu
 		return nil, false
 	}
 
-	if !dryRunner.utils.CanWriteFile(file) {
+	if !dryRunner.utils.canWriteFile(file) {
 		dryRunner.fail("permission denied: "+file, stats)
 		return nil, false
 	}
 
-	data, err := dryRunner.fileOperations.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		dryRunner.fail(err.Error(), stats)
 		return nil, false

--- a/tests/services/dry_runner_test.go
+++ b/tests/services/dry_runner_test.go
@@ -12,8 +12,7 @@ import (
 
 func TestValidateTransactionModeStopsOnFirstError(t *testing.T) {
 	utils := services.NewUtils()
-	fileOps := &services.OSFileOperations{}
-	dryRunner := services.NewDryRunner(fileOps, utils)
+	dryRunner := services.NewDryRunner(utils)
 
 	pattern := regexp.MustCompile("test")
 	command := models.Command{
@@ -41,8 +40,7 @@ func TestValidateNonTransactionModeContinuesAfterError(t *testing.T) {
 	defer os.Remove(validFile)
 
 	utils := services.NewUtils()
-	fileOps := &services.OSFileOperations{}
-	dryRunner := services.NewDryRunner(fileOps, utils)
+	dryRunner := services.NewDryRunner(utils)
 	pattern := regexp.MustCompile("content")
 	command := models.Command{
 		Action:  models.UPDATE,
@@ -67,8 +65,7 @@ func TestValidatePermissionDenied(t *testing.T) {
 	defer os.Remove(testFile)
 
 	utils := services.NewUtils()
-	fileOps := &services.OSFileOperations{}
-	dryRunner := services.NewDryRunner(fileOps, utils)
+	dryRunner := services.NewDryRunner(utils)
 
 	pattern := regexp.MustCompile("content")
 	command := models.Command{


### PR DESCRIPTION
During the initial services adaptation, several interface abstractions (Writer, FileSystemOperations, etc..) were introduced for testing purposes. These abstractions proved superfluous as no tests were actually mocking them. This PR removes these redundant wrappers, simplifying the codebase while maintaining the same functionality.