### PR TITLE
Improve query validation

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,6 +44,10 @@ func main() {
 	sql := strings.Join(flag.Args(), " ")
 
 	sqlParser := services.NewSQLParser()
+	if err := sqlParser.Validate(sql); err != nil {
+		fmt.Printf("Error: %s\n", err)
+		os.Exit(1)
+	}
 	command := sqlParser.Parse(sql)
 
 	fileFinder := services.NewFileFinder()

--- a/services/sql_parser.go
+++ b/services/sql_parser.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -11,6 +12,42 @@ type SQLParser struct{}
 
 func NewSQLParser() *SQLParser {
 	return &SQLParser{}
+}
+
+func (sqlParser *SQLParser) Validate(sql string) error {
+	sql = strings.TrimSpace(sql)
+	if sql == "" {
+		return fmt.Errorf("Query cannot be empty")
+	}
+
+	upperSql := strings.ToUpper(sql)
+
+	validPrefixes := []string{"SELECT COUNT", "SELECT", "UPDATE", "DELETE"}
+	hasValidPrefix := false
+	for _, prefix := range validPrefixes {
+		if strings.HasPrefix(upperSql, prefix) {
+			hasValidPrefix = true
+			break
+		}
+	}
+
+	if !hasValidPrefix {
+		return fmt.Errorf("Query must start with SELECT, UPDATE, or DELETE")
+	}
+
+	if strings.HasPrefix(upperSql, "SELECT") && !strings.Contains(upperSql, "FROM") {
+		return fmt.Errorf("SELECT query must contain FROM clause")
+	}
+
+	if strings.HasPrefix(upperSql, "UPDATE") && !strings.Contains(upperSql, "SET") {
+		return fmt.Errorf("UPDATE query must contain SET clause")
+	}
+
+	if strings.HasPrefix(upperSql, "DELETE") && !strings.Contains(upperSql, "FROM") {
+		return fmt.Errorf("DELETE query must contain FROM clause")
+	}
+
+	return nil
 }
 
 func (sqlParser *SQLParser) Parse(sql string) models.Command {


### PR DESCRIPTION
This PR is make to add SQL input validation by introducing a `Validate` method in `SQLParser` to check commands and required clauses. While the input was already partially validated before, it now returns clearer, more specific error messages, and `main.go` validates queries before parsing and exits on invalid SQL.