### PR TITLE
Add name parameter for column selection

### DIFF
--- a/models/command.go
+++ b/models/command.go
@@ -13,6 +13,7 @@ type Command struct {
 	Replacements []Replacement
 	Deletions    []Deletion
 	IsBatch      bool
+	SelectTarget Select
 }
 
 type Replacement struct {

--- a/models/select.go
+++ b/models/select.go
@@ -1,0 +1,9 @@
+package models
+
+type Select string
+
+const (
+	ALL     Select = "*"
+	NAME    Select = "name"
+	CONTENT Select = "content"
+)

--- a/services/commands/dispatcher.go
+++ b/services/commands/dispatcher.go
@@ -57,14 +57,14 @@ func (dispatcher *Dispatcher) Execute(command models.Command, files []string, us
 	}
 
 	if command.Action == models.COUNT {
-		total, stats := dispatcher.searcher.Count(files, command.Pattern)
-		fmt.Printf("%d lines matched\n", total)
+		total, stats := dispatcher.searcher.Count(files, command.Pattern, command.SelectTarget)
+		fmt.Printf("%d matches\n", total)
 		dispatcher.utils.PrintStats(stats)
 		return
 	}
 
 	if command.Action == models.SELECT {
-		stats := dispatcher.searcher.Select(files, command.Pattern)
+		stats := dispatcher.searcher.Select(files, command.Pattern, command.SelectTarget)
 		dispatcher.utils.PrintStats(stats)
 		return
 	}

--- a/services/commands/searcher.go
+++ b/services/commands/searcher.go
@@ -24,30 +24,60 @@ func NewSearcher(parallelizer *files.Parallelizer, utils *services.Utils) *Searc
 	}
 }
 
-func (searcher *Searcher) Count(files []string, pattern *regexp.Regexp) (int, models.ExecutionStats) {
-	stats := models.ExecutionStats{StartTime: time.Now()}
+func countMatchingLines(file string, pattern *regexp.Regexp) (int, error) {
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return 0, err
+	}
 
-	total := searcher.parallelizer.ProcessFilesInParallel(files, func(file string) (int, error) {
-		data, err := os.ReadFile(file)
-		if err != nil {
-			return 0, err
+	lines := strings.Split(string(data), "\n")
+	count := 0
+
+	for _, line := range lines {
+		if pattern.MatchString(line) {
+			count++
 		}
+	}
 
-		lines := strings.Split(string(data), "\n")
-		count := 0
-		for _, line := range lines {
-			if pattern.MatchString(line) {
-				count++
-			}
-		}
-
-		return count, nil
-	}, &stats)
-
-	return total, stats
+	return count, nil
 }
 
-func (searcher *Searcher) Select(files []string, pattern *regexp.Regexp) models.ExecutionStats {
+func (searcher *Searcher) Count(files []string, pattern *regexp.Regexp, selectTarget models.Select) (int, models.ExecutionStats) {
+	stats := models.ExecutionStats{StartTime: time.Now()}
+	switch selectTarget {
+	case models.NAME:
+		total := searcher.parallelizer.ProcessFilesInParallel(files, func(file string) (int, error) {
+			data, err := os.ReadFile(file)
+			if err != nil {
+				return 0, err
+			}
+
+			lines := strings.SplitSeq(string(data), "\n")
+			for line := range lines {
+				if pattern.MatchString(line) {
+					return 1, nil
+				}
+			}
+
+			return 0, nil
+		}, &stats)
+		return total, stats
+	case models.CONTENT, models.ALL:
+		total := searcher.parallelizer.ProcessFilesInParallel(files, func(file string) (int, error) {
+			return countMatchingLines(file, pattern)
+		}, &stats)
+
+		return total, stats
+	default:
+		total := searcher.parallelizer.ProcessFilesInParallel(files, func(file string) (int, error) {
+			return countMatchingLines(file, pattern)
+		}, &stats)
+
+		return total, stats
+	}
+}
+
+func (searcher *Searcher) Select(files []string, pattern *regexp.Regexp, selectTarget models.Select) models.ExecutionStats {
 	stats := models.ExecutionStats{StartTime: time.Now()}
 
 	searcher.parallelizer.ProcessFilesInParallelNoCount(files, func(file string) error {
@@ -57,12 +87,22 @@ func (searcher *Searcher) Select(files []string, pattern *regexp.Regexp) models.
 		}
 
 		lines := strings.Split(string(data), "\n")
+		matched := false
 		for i, line := range lines {
 			if pattern.MatchString(line) {
-				fmt.Printf("%s:%d: %s\n", file, i+1, line)
+				matched = true
+				switch selectTarget {
+				case models.CONTENT:
+					fmt.Printf("%s\n", line)
+				case models.ALL:
+					fmt.Printf("%s:%d: %s\n", file, i+1, line)
+				}
 			}
 		}
 
+		if matched && selectTarget == models.NAME {
+			fmt.Printf("%s\n", file)
+		}
 		return nil
 	}, &stats)
 

--- a/services/sql_parser.go
+++ b/services/sql_parser.go
@@ -14,6 +14,31 @@ func NewSQLParser() *SQLParser {
 	return &SQLParser{}
 }
 
+func (sqlParser *SQLParser) detectSelectTarget(sql string) models.Select {
+	upper := strings.ToUpper(sql)
+	selectIdx := strings.Index(upper, "SELECT")
+	fromIdx := strings.Index(upper, "FROM")
+	if selectIdx == -1 || fromIdx == -1 {
+		return models.ALL
+	}
+
+	selectClause := strings.TrimSpace(sql[selectIdx+6 : fromIdx])
+	selectClauseLower := strings.ToLower(selectClause)
+
+	if strings.HasPrefix(selectClauseLower, "count(") && strings.HasSuffix(selectClauseLower, ")") {
+		selectClauseLower = strings.TrimSuffix(strings.TrimPrefix(selectClauseLower, "count("), ")")
+	}
+
+	switch selectClauseLower {
+	case "name":
+		return models.NAME
+	case "content":
+		return models.CONTENT
+	default:
+		return models.ALL
+	}
+}
+
 func (sqlParser *SQLParser) Validate(sql string) error {
 	sql = strings.TrimSpace(sql)
 	if sql == "" {
@@ -55,15 +80,18 @@ func (sqlParser *SQLParser) Parse(sql string) models.Command {
 	upperSql := strings.ToUpper(sql)
 
 	var command models.Command
+	command.SelectTarget = models.ALL
 
 	if strings.HasPrefix(upperSql, "SELECT COUNT") {
 		command.Action = models.COUNT
 		command.File = sqlParser.extractBetween(sql, "FROM", "WHERE")
+		command.SelectTarget = sqlParser.detectSelectTarget(sql)
 	}
 
 	if strings.HasPrefix(upperSql, "SELECT") && !strings.HasPrefix(upperSql, "SELECT COUNT") {
 		command.Action = models.SELECT
 		command.File = sqlParser.extractBetween(sql, "FROM", "WHERE")
+		command.SelectTarget = sqlParser.detectSelectTarget(sql)
 	}
 
 	if strings.HasPrefix(upperSql, "UPDATE") {


### PR DESCRIPTION
This PR is made to introduce a SelectTarget field that lets users choose whether a search targets file names, content, or both. It updates parsing, dispatching, and search execution to support `SELECT name | content | *` with more granular control over query results.